### PR TITLE
Issue #4: Set IP to 0.0.0.0 for all networks allowed into the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### MkDocs in a docker.
 
-[![Build Status](https://jenkins.ozgo.info/jenkins/view/GitHub%20-%20Docker/job/gh-pozgo-docker-mkdocs/badge/icon)](https://jenkins.ozgo.info/jenkins/view/GitHub%20-%20Docker/job/gh-pozgo-docker-mkdocs/)  
+[![Build Status](https://jenkins.ozgo.info/jenkins/buildStatus/icon?job=gh-pozgo-docker-mkdocs)](https://jenkins.ozgo.info/jenkins/view/GitHub%20-%20Docker/job/gh-pozgo-docker-mkdocs/)  
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fpozgo%2Fdocker-mkdocs.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fpozgo%2Fdocker-mkdocs?ref=badge_shield)
 
 [![GitHub Open Issues](https://img.shields.io/github/issues/pozgo/docker-mkdocs.svg)](https://github.com/pozgo/docker-mkdocs/issues)

--- a/container-files/bootstrap.sh
+++ b/container-files/bootstrap.sh
@@ -19,7 +19,7 @@ start_mkdocs () {
     fi
     cd /workdir/mkdocs
     echo "Starting MKDocs"
-    mkdocs serve -a $(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1):8000 $LRS
+    mkdocs serve -a 0.0.0.0:8000 $LRS
 }
 
 get_docs () {


### PR DESCRIPTION
### Changes:

- `serve` set to use 0.0.0.0 as IP for all newtorks to be allowed connection. 

### BugFixes: 
- `README.md` build status badge fixed