### PR TITLE
Issue-#8: Fixed auto-reload

### DIFF
--- a/container-files/bootstrap.sh
+++ b/container-files/bootstrap.sh
@@ -2,37 +2,40 @@
 set -eu
 #### "Magic starts Here" - H. Potter #####
 check_install_status () {
-    if [[ ! -e /workdir/mkdocs ]]; then
-        mkdir -p /workdir/mkdocs
-    fi
-    cd /workdir/mkdocs
-    if [[ ! -e "mkdocs.yml" ]]; then
+  if [[ ! -e /workdir/mkdocs ]]; then
+    echo "No documentation folder available. Creating new one."
+    mkdir -p /workdir/mkdocs
+  fi
+  cd /workdir/mkdocs
+  if [[ ! -e "mkdocs.yml" ]]; then
     echo "No previous config. Starting fresh instalation"
     mkdocs new .
-    fi
+  fi
 }
 start_mkdocs () {
-    if [[ ${LIVE_RELOAD_SUPPORT} == 'true' ]]; then
-        LRS='--no-livereload'
-    else
-        LRS=''
-    fi
-    cd /workdir/mkdocs
-    echo "Starting MKDocs"
-    mkdocs serve -a 0.0.0.0:8000 $LRS
+  if [[ ${LIVE_RELOAD_SUPPORT} != 'true' ]]; then
+    echo "[ DISABLED ] - livereload"
+    LRS='--no-livereload'
+  else
+    echo "[ ENABLED ] - livereload"
+    LRS=''
+  fi
+  cd /workdir/mkdocs
+  echo "Starting MKDocs"
+  mkdocs serve -a 0.0.0.0:8000 $LRS
 }
 
 get_docs () {
-    if [[ ! -e /workdir/mkdocs ]]; then
-        echo "Downloading documentation from Git Repository"
-        git clone ${GIT_REPO} /workdir/mkdocs
-    fi
+  if [[ ! -e /workdir/mkdocs ]]; then
+    echo "Downloading documentation from Git Repository"
+    git clone ${GIT_REPO} /workdir/mkdocs
+  fi
 }
 
 if [ ${GIT_REPO} != 'false' ]; then
-    get_docs
-    start_mkdocs
+  get_docs
+  start_mkdocs
 else
-    check_install_status
-    start_mkdocs
+  check_install_status
+  start_mkdocs
 fi


### PR DESCRIPTION
### Changes
- Issue-#8: Fixed auto-reload 
- Tidy up `bootstrap.sh`
- `bootstrap.sh` made more verbose

### Tests
Tested on local machine. Logs below.

```bash
docker run \
    -ti \
    --rm \
    --name mkdocs \
    -p 8000:8000 \
    -v ${PWD}/data:/workdir \
    -e LIVE_RELOAD_SUPPORT='true' \
    polinux/mkdocs
[ ENABLED ] - livereload
Starting MKDocs
INFO    -  Building documentation...
INFO    -  Cleaning site directory
[I 191215 17:32:21 server:296] Serving on http://0.0.0.0:8000
[I 191215 17:32:21 handlers:62] Start watching changes
[I 191215 17:32:21 handlers:64] Start detecting changes
```