### PR TITLE
Fixes #36: Added build-base and stopped removing off dev package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,11 @@ RUN \
         git \
         openssh \
         python3 \
-        python3-dev && \
+        python3-dev \
+        build-base && \
     pip3 install --upgrade pip && \
     pip install mkdocs==${MKDOCS_VERSION} && \
     cd /bootstrap && pip install -e /bootstrap && \
-    apk del python3-dev && \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/* && \
     chmod 600 /root/.ssh/config
 


### PR DESCRIPTION
### Changelog
- Added `build-base` with `gcc` - required if modules need to be built on runtime
- Keeping `python3-dev` package after build - same reason as bove