### PR TITLE
Updated MKDOCS_VERSION env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-ENV MKDOCS_VERSION=1.1.0 \
+ENV MKDOCS_VERSION=1.1.2 \
     DOCS_DIRECTORY='/mkdocs' \
     LIVE_RELOAD_SUPPORT='false' \
     ADD_MODULES='false' \


### PR DESCRIPTION
I updated the ENV variable for mkdocs version, since i can't modify the installed version via the environment variables from `docker-compose.yml` file.
Another reason is, that the version 1.1.0 seems to be a `dirty build` (information from `docker container logs mkdocs` after startup).