### PR TITLE
Fix#69: Fixed auto-update function

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN \
     pip install --upgrade pip && \
     pip install mkdocs==${MKDOCS_VERSION} && \
     cd /bootstrap && pip install -e /bootstrap && \
+    cp -r /bootstrap/app/ /usr/bin/ && \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/* && \
     chmod 600 /root/.ssh/config
 

--- a/Dockerfile-arm64v8
+++ b/Dockerfile-arm64v8
@@ -26,6 +26,7 @@ RUN \
   pip install --upgrade pip && \
   pip install mkdocs==${MKDOCS_VERSION} && \
   cd /bootstrap && pip install -e /bootstrap && \
+  cp -r /bootstrap/app/ /usr/bin/ && \
   rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/* && \
   chmod 600 /root/.ssh/config
 


### PR DESCRIPTION
Applied workaround discussed in issue #69 

This workaround lets you run the manual update with `docker exec -ti mkdocs bootstrap update` **or** await the interval for the auto-update. 

Tested locally